### PR TITLE
refactor: changed call to config-file in update-sample-sheet

### DIFF
--- a/workflow/scripts/update-sample-sheet.py
+++ b/workflow/scripts/update-sample-sheet.py
@@ -14,10 +14,9 @@ import pandas as pd
 
 # define location of sample sheet and workflow configx
 SAMPLE_SHEET = snakemake.input[0]  # "config/pep/samples.csv"
-CONFIG_YAML = "config/config.yaml"
 
 
-def update_sample_sheet(SAMPLE_SHEET, CONFIG_YAML, verbose=True, dry_run=False):
+def update_sample_sheet(SAMPLE_SHEET, verbose=True, dry_run=False):
     """
     This function
         - copies files from the incoming data directory to the snakemake data directory and
@@ -52,12 +51,7 @@ def update_sample_sheet(SAMPLE_SHEET, CONFIG_YAML, verbose=True, dry_run=False):
 
     today = date.today().strftime("%Y-%m-%d")
 
-    # load path from config
-    with open(CONFIG_YAML, "r") as stream:
-        try:
-            config = yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
-            print(exc)
+    config = snakemake.config
 
     DATA_PATH = str(config["data-handling"]["data"])
     IN_PATH = str(config["data-handling"]["incoming"])
@@ -245,4 +239,4 @@ def update_sample_sheet(SAMPLE_SHEET, CONFIG_YAML, verbose=True, dry_run=False):
                 new_sample_sheet.to_csv(ARCHIVE_PATH + today + "/samples.csv")
 
 
-update_sample_sheet(SAMPLE_SHEET, CONFIG_YAML)
+update_sample_sheet(SAMPLE_SHEET)


### PR DESCRIPTION
<details><summary>Expected commit message structure</summary>

Commit messages should be structured as follows:

```
<type>[optional scope]: <description>

[optional body]

[optional footer]
```

## Type
Must be one of the following:

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- **test**: Adding missing tests or correcting existing tests

## Examples

Commit message with description and breaking change in body
```
feat: allow provided config object to extend other configs

BREAKING CHANGE: `extends` key in config file is now used for extending other config files
```

Commit message with no body
```
docs: correct spelling of CHANGELOG
````

Commit message with scope
```
feat(lang): added polish language
```

Commit message for a fix using an (optional) issue number.
```
fix: minor typos in code

see the issue for details on the typos fixed

fixes issue #12
```

</p>
</details>
