### PR TITLE
build: temporarily change MultiQC wrapper to env rule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,8 +153,8 @@ jobs:
       - name: Use smaller reference files for testing
         if: steps.test-resources.outputs.cache-hit != true
         run: |
-          mkdir -p .tests/resources/minikraken-8GB
-          curl -SL https://github.com/thomasbtf/small-kraken-db/raw/master/human_k2db.tar.gz | tar zxvf - -C .tests/resources/minikraken-8GB --strip 1
+          # mkdir -p .tests/resources/minikraken-8GB
+          # curl -SL https://github.com/thomasbtf/small-kraken-db/raw/master/human_k2db.tar.gz | tar zxvf - -C .tests/resources/minikraken-8GB --strip 1
           mkdir -p .tests/resources/genomes
           curl -SL "https://www.ncbi.nlm.nih.gov/sviewer/viewer.fcgi?id=NC_000021.9&db=nuccore&report=fasta" | gzip -c > .tests/resources/genomes/human-genome.fna.gz
 

--- a/workflow/envs/multiqc.yaml
+++ b/workflow/envs/multiqc.yaml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - multiqc =1.11

--- a/workflow/envs/snakemake.yaml
+++ b/workflow/envs/snakemake.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - snakemake =6.7
+  - snakemake =6.10

--- a/workflow/envs/snakemake.yaml
+++ b/workflow/envs/snakemake.yaml
@@ -3,4 +3,3 @@ channels:
   - conda-forge
 dependencies:
   - snakemake =6.10
-  - peppy >= 0.31.2

--- a/workflow/envs/snakemake.yaml
+++ b/workflow/envs/snakemake.yaml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - snakemake =6.10
+  - peppy >= 0.31.2

--- a/workflow/notebooks/call-strains.py.ipynb
+++ b/workflow/notebooks/call-strains.py.ipynb
@@ -2,13 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
+    "\n",
     "sys.stderr = open(snakemake.log[0], \"w\")\n",
-    "import pandas as pd\n",
+    "\n",
     "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
     "import pysam\n",
     "\n",
     "min_fraction = snakemake.params.get(\"min_fraction\", 0.01)\n",
@@ -46,7 +50,7 @@
     "quant = quant.set_index(\"target_id\", drop=True)\n",
     "\n",
     "# store results\n",
-    "quant.to_csv(snakemake.output[0], sep=\"\\t\")"
+    "quant.to_csv(snakemake.output[0], sep=\"\\t\")\n"
    ]
   }
  ],
@@ -66,7 +70,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -3,6 +3,7 @@
 # This file may not be copied, modified, or distributed
 # except according to those terms.
 
+
 rule fastqc:
     input:
         get_fastqs,
@@ -43,6 +44,8 @@ rule multiqc:
 
 # TODO: Change back to MultiQC wrapper once v1.11 is released
 from os import path
+
+
 rule multiqc_lab:
     input:
         expand_samples_for_date(
@@ -62,10 +65,10 @@ rule multiqc_lab:
             subcategory="1. Quality Control",
         ),
     params:
-        input_dirs = lambda w, input: set(path.dirname(fp) for fp in snakemake.input),
-        output_dir = lambda w, output: path.dirname(snakemake.output[0]),
-        output_name = lambda w, output: path.basename(snakemake.output[0]),
-        params="--config config/multiqc_config_lab.yaml --title 'Results for data from {date}'"
+        input_dirs=lambda w, input: set(path.dirname(fp) for fp in snakemake.input),
+        output_dir=lambda w, output: path.dirname(snakemake.output[0]),
+        output_name=lambda w, output: path.basename(snakemake.output[0]),
+        params="--config config/multiqc_config_lab.yaml --title 'Results for data from {date}'",
     conda:
         "../envs/multiqc.yaml"
     log:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -65,17 +65,17 @@ rule multiqc_lab:
             subcategory="1. Quality Control",
         ),
     params:
-        input_dirs=lambda w, input: set(path.dirname(fp) for fp in snakemake.input),
-        output_dir=lambda w, output: path.dirname(snakemake.output[0]),
-        output_name=lambda w, output: path.basename(snakemake.output[0]),
+        input_dirs=lambda w, input: set(path.dirname(fp) for fp in input),
+        output_dir=lambda w, output: path.dirname(output[0]),
+        output_name=lambda w, output: path.basename(output[0]),
         params="--config config/multiqc_config_lab.yaml --title 'Results for data from {date}'",
     conda:
         "../envs/multiqc.yaml"
     log:
         "logs/{date}/multiqc.log",
     shell:
-        "multiqc {params.params} --force -o {params.output_dir} -n {params.output_name} "
-        " {params.input} 2> {log}"
+        "multiqc {params.params} --force -o {params.output_dir} "
+        "-n {params.output_name} {params.input_dirs} 2> {log}"
 
 
 rule samtools_flagstat:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -19,6 +19,7 @@ rule fastqc:
 # TODO: Change multiqc rules back to MultiQC wrapper once v1.11 is released
 from os import path
 
+
 rule multiqc:
     input:
         expand_samples_for_date(


### PR DESCRIPTION
<details><summary>Expected commit message structure</summary>

Commit messages should be structured as follows:

```
<type>[optional scope]: <description>

[optional body]

[optional footer]
```

## Type
Must be one of the following:

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- **test**: Adding missing tests or correcting existing tests

## Examples

Commit message with description and breaking change in body
```
feat: allow provided config object to extend other configs

BREAKING CHANGE: `extends` key in config file is now used for extending other config files
```

Commit message with no body
```
docs: correct spelling of CHANGELOG
````

Commit message with scope
```
feat(lang): added polish language
```

Commit message for a fix using an (optional) issue number.
```
fix: minor typos in code

see the issue for details on the typos fixed

fixes issue #12
```

</p>
</details>
