### PR TITLE
fix: add bam index for extract_reads_of_interest

### DIFF
--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -184,7 +184,7 @@ rule combine_references:
 rule extract_reads_of_interest:
     input:
         bam="results/{date}/mapped/ref~main+human/{sample}.bam",
-        index="results/{date}/mapped/ref~main+human/{sample}.bam.bai"
+        index="results/{date}/mapped/ref~main+human/{sample}.bam.bai",
     output:
         temp("results/{date}/mapped/ref~main+human/nonhuman/{sample}.bam"),
     log:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -183,7 +183,8 @@ rule combine_references:
 # filter out human contamination
 rule extract_reads_of_interest:
     input:
-        "results/{date}/mapped/ref~main+human/{sample}.bam",
+        bam="results/{date}/mapped/ref~main+human/{sample}.bam",
+        index="results/{date}/mapped/ref~main+human/{sample}.bam.bai"
     output:
         temp("results/{date}/mapped/ref~main+human/nonhuman/{sample}.bam"),
     log:

--- a/workflow/scripts/extract-reads-of-interest.py
+++ b/workflow/scripts/extract-reads-of-interest.py
@@ -19,7 +19,7 @@ def is_sars_cov2(record, mate=False):
         return record.reference_name.startswith(sars_cov2_id)
 
 
-with pysam.AlignmentFile(snakemake.input[0], "rb") as inbam:
+with pysam.AlignmentFile(snakemake.input.bam, "rb") as inbam:
     with pysam.AlignmentFile(snakemake.output[0], "wb", template=inbam) as outbam:
         for record in inbam:
             assert record.is_paired


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Add index to rule `extract_reads_of_interest`. This removes the following message:

```python
[E::idx_find_and_load] Could not retrieve index file for 'results/{date}/mapped/ref~main+human/{sample}.bam'
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've structured the [PR title as a Conventional Commits message](https://www.conventionalcommits.org/en/v1.0.0/) (`<type>[optional scope]: <description>`)
- [x] I've updated the code style using `snakefmt workflow/` and `black workflow/`.
- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md) guide.

## Type of Changes

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) 
Add the change in the title of this PR: <type>[optional scope]: <description> -->

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
