### PR TITLE
fix: GISAID lineage extraction [B.1.1.529 (probably).fasta]

### DIFF
--- a/workflow/rules/long_read.smk
+++ b/workflow/rules/long_read.smk
@@ -3,6 +3,7 @@
 # This file may not be copied, modified, or distributed
 # except according to those terms.
 
+
 rule nanoQC:
     input:
         get_reads_by_stage,

--- a/workflow/scripts/extract-strains-from-gisaid-provision.py
+++ b/workflow/scripts/extract-strains-from-gisaid-provision.py
@@ -57,7 +57,7 @@ def select_oldest_strains(df: pd.DataFrame):
         & (df["covv_lineage"] != "None")
         & (df["covv_lineage"] != "")
         & ~(df["covv_lineage"].str.contains("\("))
-        & ~(df["covv_lineage"].str.contains("\)")
+        & ~(df["covv_lineage"].str.contains("\)"))
     )
     cols_of_interesst = ["covv_lineage", "n_content", "covv_subm_date"]
     df = df.copy()

--- a/workflow/scripts/extract-strains-from-gisaid-provision.py
+++ b/workflow/scripts/extract-strains-from-gisaid-provision.py
@@ -56,6 +56,8 @@ def select_oldest_strains(df: pd.DataFrame):
         & (df["is_complete"] == True)
         & (df["covv_lineage"] != "None")
         & (df["covv_lineage"] != "")
+        & ~(df["covv_lineage"].str.contains("\("))
+        & ~(df["covv_lineage"].str.contains("\)")
     )
     cols_of_interesst = ["covv_lineage", "n_content", "covv_subm_date"]
     df = df.copy()


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Currently, there is a file in GISAID EpiCoV DataBase which is called `B.1.1.529 (probably).fasta` (omicron). This file causes downstream problems when casting all lineage genomes together, due to the spaces and parenthesis.  

This PR removes lineage, that contains parenthesis in the name from extraction.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title  in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I've updated the code style using `snakefmt workflow/` and `black workflow/` if needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md) guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->
