### PR TITLE
fix: reset overview table formatter to older version

### DIFF
--- a/resources/report-table-formatter.js
+++ b/resources/report-table-formatter.js
@@ -1,100 +1,101 @@
 {
-  "Pango Lineage" : function format(value) { // prettier-ignore
-    $(function () {
-      $('[data-toggle="tooltip"]').tooltip();
-    });
+  "Pango Lineage": function format(value) {
+      $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+      })
 
-    if (value !== "no strain called") {
-      var link = `<a data-toggle="tooltip" data-placement="top" title="View ${value} on outbreak.info" href='https://outbreak.info/situation-reports?pango=${value}' target='_blank'>${value}</a>`;
-      return link;
-    } else {
-      return value;
-    }
-  }
-  "variant helper" : function format(value, voi) {
-    $(function () {
-      $('[data-toggle="popover"]').popover();
-    });
-
-    $(function () {
-      $('[data-toggle="tooltip"]').tooltip();
-    });
-
-    $(".popover-dismiss").popover({
-      trigger: "focus",
-    });
-
-    var variants = value.split(" ");
-    var genes = [];
-    var vafs = {};
-    var vats = {};
-    for (var v of variants) {
-      var split = v.split(":");
-      genes.push(split[0]);
-    }
-
-    for (var g of genes) {
-      vafs[g] = [];
-      vats[g] = [];
-    }
-
-    for (var v of variants) {
-      var split = v.split(":");
-      vafs[split[0]].push(split[2]);
-      vats[split[0]].push(split[1]);
-    }
-
-    const table = `<table class="table">
-                <thead>
-                    <tr>
-                    <th scope="col">Variant</th>
-                    <th scope="col">VAF</th>
-                    </tr>
-                </thead>
-                <tbody>`;
-
-    const table_end = "</tbody></table>";
-
-    var tables = {};
-
-    for (g of genes) {
-      var body = "";
-      for (let i = 0; i < vafs[g].length; i++) {
-        var row = `<tr><td scope="col">${vats[g][i]}</td><td>${vafs[g][i]}</td></tr>`;
-        body = body + row;
-      }
-      tables[g] = table + body + table_end;
-    }
-
-    let result = [];
-    let unique_genes = [...new Set(genes)];
-
-    for (g of unique_genes) {
-      if (voi) {
-        var x = "";
-        for (let i = 0; i < vats[g].length; i++) {
-          var x = `<a href="#" data-toggle="popover" data-trigger="focus" data-html='true' title='Gene: <a data-html="true" data-toggle="tooltip" data-placement="bottom" title="Linkout to gene in Ensembl genome browser" href="https://covid-19.ensembl.org/Sars_cov_2/Gene/Summary?g=${g}" target="_blank">${g}:${vats[g][i]}</a>' data-content='${tables[g]}'>${g}:${vats[g][i]}</a>`;
-          result.push(x);
-        }
+      if (value !== "no strain called") {
+          var link = `<a data-toggle="tooltip" data-placement="top" title="View ${value} on outbreak.info" href='https://outbreak.info/situation-reports?pango=${value}' target='_blank'>${value}</a>`;
+          return link;
       } else {
-        var x = `<a href="#" data-toggle="popover" data-trigger="focus" data-html='true' title='Gene: <a data-html="true" data-toggle="tooltip" data-placement="bottom" title="Linkout to gene in Ensembl genome browser" href="https://covid-19.ensembl.org/Sars_cov_2/Gene/Summary?g=${g}" target="_blank">${g}</a>' data-content='${tables[g]}'>${g}</a>`;
-        result.push(x);
+          return value;
       }
-    }
+  },
+  "variant helper": function format(value, voi) {
+      $(function () {
+          $('[data-toggle="popover"]').popover()
+      })
 
-    result = result.join(", ");
+      $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+      })
 
-    if (value.trim() !== "") {
+      $('.popover-dismiss').popover({
+          trigger: 'focus'
+      })
+
+      var variants = value.split(' ');
+      var genes = [];
+      var vafs = {};
+      var vats = {};
+      for (var v of variants) {
+          var split = v.split(':');
+          genes.push(split[0]);
+      }
+
+      for (var g of genes) {
+          vafs[g] = [];
+          vats[g] = [];
+      }
+
+      for (var v of variants) {
+          var split = v.split(':');
+          vafs[split[0]].push(split[2]);
+          vats[split[0]].push(split[1]);
+      }
+
+      const table = `<table class="table">
+              <thead>
+                  <tr>
+                  <th scope="col">Variant</th>
+                  <th scope="col">VAF</th>
+                  </tr>
+              </thead>
+              <tbody>`;
+
+      const table_end = "</tbody></table>";
+
+      var tables = {};
+
+      for (g of genes) {
+          var body = "";
+          for (let i = 0; i < vafs[g].length; i++) {
+              var row = `<tr><td scope="col">${vats[g][i]}</td><td>${vafs[g][i]}</td></tr>`;
+              body = body + row;
+          }
+          tables[g] = table + body + table_end;
+      }
+
+      let result = [];
+      let unique_genes = [...new Set(genes)];
+
+      for (g of unique_genes) {
+          if (voi) {
+              var x = "";
+              for (let i = 0; i < vats[g].length; i++) {
+                  var x = `<a href="#" data-toggle="popover" data-trigger="focus" data-html='true' title='Gene: <a data-html="true" data-toggle="tooltip" data-placement="bottom" title="Linkout to gene in Ensembl genome browser" href="https://covid-19.ensembl.org/Sars_cov_2/Gene/Summary?g=${g}" target="_blank">${g}:${vats[g][i]}</a>' data-content='${tables[g]}'>${g}:${vats[g][i]}</a>`;
+                  result.push(x);
+              }
+          } else {
+              var x = `<a href="#" data-toggle="popover" data-trigger="focus" data-html='true' title='Gene: <a data-html="true" data-toggle="tooltip" data-placement="bottom" title="Linkout to gene in Ensembl genome browser" href="https://covid-19.ensembl.org/Sars_cov_2/Gene/Summary?g=${g}" target="_blank">${g}</a>' data-content='${tables[g]}'>${g}</a>`;
+              result.push(x);
+          }
+      }
+
+      result = result.join(", ");
+
+      if (value.trim() !== "") {
+          return result;
+      } else {
+          return "";
+      }
+
+  },
+  "VOC Mutations": function format(value) {
+      return this["variant helper"](value, true);
+  },
+  "Other Mutations": function format(value) {
+      let result = this["variant helper"](value, false);
       return result;
-    } else {
-      return "";
-    }
-  }
-  "VOC Mutations" : function format(value) {
-    return this["variant helper"](value, true);
-  }
-  "Other Mutations" : function format(value) {
-    let result = this["variant helper"](value, false);
-    return result;
   }
 }


### PR DESCRIPTION
# Description

<!-- Add a more detailed description of the changes if needed. -->
The overview table is still broken. This PR resets the formatted to an older version (3af43b991af218931996d9093ecf944bff907476)

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [ ] I've updated or supplemented the documentation as needed.
- [X] I've read the [`CODE_OF_CONDUCT.md`] document.
- [X] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
