### PR TITLE
fix: fixed include flag KeyError

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1286,8 +1286,6 @@ def get_include_flag_for_date(wildcards):
             ):
                 if sample in sample_path:
                     allsamplelist.append(sample)
-                else:
-                    continue
         return [get_include_flag(sample) for sample in allsamplelist]
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1272,10 +1272,23 @@ def get_include_flag(sample):
 
 
 def get_include_flag_for_date(wildcards):
-    return [
-        get_include_flag(sample)
-        for sample in get_assemblies_for_submission(wildcards, "accepted samples")
-    ]
+    if len(get_samples_for_date(wildcards.date)) == len(
+        get_assemblies_for_submission(wildcards, "accepted samples")
+    ):
+        return [
+            get_include_flag(sample) for sample in get_samples_for_date(wildcards.date)
+        ]
+    else:
+        allsamplelist = []
+        for sample in get_samples_for_date(wildcards.date):
+            for sample_path in get_assemblies_for_submission(
+                wildcards, "accepted samples"
+            ):
+                if sample in sample_path:
+                    allsamplelist.append(sample)
+                else:
+                    continue
+        return [get_include_flag(sample) for sample in allsamplelist]
 
 
 def get_artic_primer(wildcards):


### PR DESCRIPTION
# Description

<!-- Add a more detailed description of the changes if needed. --> There was a problem with the include_flag in common.smk. The get_assemblies_for_submission function gives the path to the faster file, not the name, leading to a KeyError in get_include_flag. This causes the inclusion of files in the high-quality-genomes, that should be excluded. Problem fixed by changing the functions used in get_include_flag_for_date and taking into account the lengths of the lists from get_assemblies_for_submission and get_sample_for_date.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [ ] I've updated or supplemented the documentation as needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
