### PR TITLE
fix: pangolin plot

### DIFF
--- a/workflow/notebooks/plot-all-strains-pangolin.py.ipynb
+++ b/workflow/notebooks/plot-all-strains-pangolin.py.ipynb
@@ -18,12 +18,10 @@
     "\n",
     "all_calls = pd.concat(all_calls)\n",
     "all_calls[\"count\"] = 1\n",
-    "all_calls.rename(columns={\"scorpio_support\": \"probability\"}, inplace=True)\n",
     "\n",
     "alt.Chart(all_calls).mark_bar().encode(\n",
     "    x=alt.X(\"sum(count):Q\", title=\"count\"),\n",
     "    y=alt.Y(\"lineage\", title=\"\"),\n",
-    "    color=alt.Color(\"probability\", scale=alt.Scale(domain=[0.0, 1.0])),\n",
     ").save(snakemake.output[0])"
    ]
   }


### PR DESCRIPTION
# Description

In the aggregation plot of all pangolin calls, samples were only included if they had a value for scorpio support. To fix that the value was excluded from the plotting script

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [x] I've updated or supplemented the documentation as needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
