### PR TITLE
fix(ci): change human reference from NC_000021.9 to BA000005.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
           # mkdir -p .tests/resources/minikraken-8GB
           # curl -SL https://github.com/thomasbtf/small-kraken-db/raw/master/human_k2db.tar.gz | tar zxvf - -C .tests/resources/minikraken-8GB --strip 1
           mkdir -p .tests/resources/genomes
-          curl -SL "https://www.ncbi.nlm.nih.gov/sviewer/viewer.fcgi?id=NC_000021.9&db=nuccore&report=fasta" | gzip -c > .tests/resources/genomes/human-genome.fna.gz
+          curl -SL "https://www.ncbi.nlm.nih.gov/sviewer/viewer.fcgi?id=BA000005.3&db=nuccore&report=fasta" | gzip -c > .tests/resources/genomes/human-genome.fna.gz
       - name: Simulate GISAID download
         run: |
           mkdir -p .tests/results/benchmarking/tables

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,7 +300,7 @@ jobs:
           # mkdir -p .tests/resources/minikraken-8GB
           # curl -SL https://github.com/thomasbtf/small-kraken-db/raw/master/human_k2db.tar.gz | tar zxvf - -C .tests/resources/minikraken-8GB --strip 1
           mkdir -p .tests/resources/genomes
-          curl -SL "https://www.ncbi.nlm.nih.gov/sviewer/viewer.fcgi?id=NC_000021.9&db=nuccore&report=fasta" | gzip -c > .tests/resources/genomes/human-genome.fna.gz
+          curl -SL "https://www.ncbi.nlm.nih.gov/sviewer/viewer.fcgi?id=BA000005.3&db=nuccore&report=fasta" | gzip -c > .tests/resources/genomes/human-genome.fna.gz
       - name: Simulate GISAID download
         run: |
           mkdir -p .tests/results/benchmarking/tables

--- a/workflow/envs/snakemake.yaml
+++ b/workflow/envs/snakemake.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - snakemake =6.10
+  - snakemake =7.0


### PR DESCRIPTION
# Description

<!-- Add a more detailed description of the changes if needed. -->
The download of `NC_000021.9` fails, because of an internal sever error over at ncbi:

```bash
...
CCCTCTCCCTCACTCTTATAAGGACACTTAAGATTGCATTTAGAGCCCACCAAGATAATTCATGATAATC
TTCCATCACAAAATTCTTCACTTATTCACATCTGCAAGTCTCTTTGCCATAAAGGTTACATTTACAGGTA
CTAAGGATTAAGACCTGACATCTCTTGAGGCCATTATTCACCCTAACACA<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
<html>
<head>
<title>NCBI/ffsrv12 - WWW Error 500 Diagnostic</title>
<style type="text/css">
h1.error {color: red; font-size: 40pt}
div.diags {text-indent: 0.5in }
</style>
</head>
<body>
<h1>Server Error</h1>


<p>Your request could not be processed due to a problem on
our Web server.  This could be a transient problem, please
try the query again.  If it doesn't clear up within a
reasonable period of time, e-mail a short description of your
query and the diagnostic information shown below to:</p>

<p>
pubmed@nlm.nih.gov - for problems with PubMed<br/>
webadmin@ncbi.nlm.nih.gov - for problems with other services<br/>
</p>

<p>Thank you for your assistance.  We will try to fix the
problem as soon as possible.
</p>
<hr/>
<p>
Diagnostic Information:</p>

<div class="diags">Error: 500</div>

<div class="diags">URL:  h t t p : / / w w w . n c b i . n l m . n i h . g o v / s v i e w e r / f l a t f i l e / f l a t f i l e . f c g i ? & a m p ; d b = n u c c o r e & a m p ; i d = N C _ 0 0 0 0 2 1 . 9 & a m p ; r e p o r t = 4 & a m p ; r e t m o d e = h t m l & a m p ; n c b i _ p h i d = 3 5 8 E 5 0 5 6 2 1 8 A A 2 8 1 0 0 0 0 0 0 F F F F F F 0 0 0 1 . 1 </div>

<div class="diags">Client: 130.14.26.24</div>

<div class="diags">Server: ffsrv12</div>

<div class="diags">Time: Fri Feb 25 05:08:35 EST 2022</div>


<p>
NOTE: The above is an internal URL which may differ from the one you used to address the page.</p>
<hr/>
<p>Rev. 01/04/08</p>

</body>
</html>
```

We only use NC_000021.9 in our CI, because it is only a small section of the human genome (chromosome 21). This PR changes to another chromosome 21 reference: https://www.ncbi.nlm.nih.gov/nuccore/BA000005.3

This will hopefully not produce the error above.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
N/A

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [X] I've updated or supplemented the documentation as needed.
- [X] I've read the [`CODE_OF_CONDUCT.md`] document.
- [X] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
