### PR TITLE
feat: make sending lab column in rki report csv adjustable via config file

### DIFF
--- a/.tests/config/config.yaml
+++ b/.tests/config/config.yaml
@@ -23,6 +23,8 @@ virus-reference-genome:
 human-genome-download-path:
   - ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.28_GRCh38.p13/GCA_000001405.28_GRCh38.p13_genomic.fna.gz
 
+sending_lab_number: 10259
+
 data-handling:
   # flag for using the following data-handling structure
   # True: data-handling structure is used as shown below

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,6 +11,8 @@ virus-reference-genome:
 human-genome-download-path:
   - ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.28_GRCh38.p13/GCA_000001405.28_GRCh38.p13_genomic.fna.gz
 
+sending_lab_number: 10259
+
 data-handling:
   # flag for using the following data-handling structure
   # True: data-handling structure is used as shown below

--- a/workflow/rules/generate_output.smk
+++ b/workflow/rules/generate_output.smk
@@ -111,6 +111,7 @@ rule high_quality_genomes_report:
     params:
         includeflag=get_include_flag_for_date,
         sending_lab_number=config["sending_lab_number"],
+        date_draw=lambda wildcards: wildcards.date,
         seq_type=lambda wildcards: get_assemblies_for_submission(
             wildcards, "accepted samples technology"
         ),

--- a/workflow/rules/generate_output.smk
+++ b/workflow/rules/generate_output.smk
@@ -4,6 +4,9 @@
 # except according to those terms.
 
 
+configfile: "config/config.yaml"
+
+
 rule masking:
     input:
         bamfile="results/{date}/mapped/ref~{reference}-{sample}/{sample}.bam",
@@ -107,6 +110,7 @@ rule high_quality_genomes_report:
         ),
     params:
         includeflag=get_include_flag_for_date,
+        sending_lab_number=config["sending_lab_number"],
         seq_type=lambda wildcards: get_assemblies_for_submission(
             wildcards, "accepted samples technology"
         ),

--- a/workflow/scripts/generate-high-quality-report.py
+++ b/workflow/scripts/generate-high-quality-report.py
@@ -52,7 +52,7 @@ else:
     csv_table = pd.DataFrame(
         {
             "SENDING_LAB": snakemake.params.sending_lab_number,
-            "DATE_DRAW": "",
+            "DATE_DRAW": snakemake.params.date_draw,
             "SEQ_TYPE": snakemake.params.seq_type,
             "SEQ_REASON": "N",
             "SAMPLE_TYPE": "s001",

--- a/workflow/scripts/generate-high-quality-report.py
+++ b/workflow/scripts/generate-high-quality-report.py
@@ -51,7 +51,7 @@ else:
     # Creating csv-table
     csv_table = pd.DataFrame(
         {
-            "SENDING_LAB": 10259,
+            "SENDING_LAB": snakemake.params.sending_lab_number,
             "DATE_DRAW": "",
             "SEQ_TYPE": snakemake.params.seq_type,
             "SEQ_REASON": "N",


### PR DESCRIPTION
# Description

- added a new parameter _sending_lab_number_ to the config file in order to make the sending lab column in RKI report csv adjustable
- the date of the current run is now also used to refill the column DATE_DRAW in RKI report csv

## Related Issue

https://github.com/IKIM-Essen/uncovar/issues/334

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [ x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [ ] I've updated or supplemented the documentation as needed.
- [ x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [ x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
