### PR TITLE
fix: add nofilter flag for variant calls

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -601,9 +601,9 @@ def get_target_events(wildcards):
 
 
 def get_control_fdr_input(wildcards):
-    if wildcards.reference == "main" and widlcards.filter != "nofilter":
+    if wildcards.reference == "main" and wildcards.filter != "nofilter":
         return "results/{date}/filtered-calls/ref~{reference}/annot~{annotation}/{sample}.{filter}.bcf"
-    elif wildcards.reference == "main" and widlcards.filter == "nofilter":
+    elif wildcards.reference == "main" and wildcards.filter == "nofilter":
         # use directly the annotated output, instead of the filtered one
         return "results/{date}/annotated-calls/ref~{reference}/annot~{annotation}/{sample}.bcf"
     else:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -605,7 +605,7 @@ def get_control_fdr_input(wildcards):
         return "results/{date}/filtered-calls/ref~{reference}/annot~{annotation}/{sample}.{filter}.bcf"
     elif wildcards.reference == "main" and widlcards.filter == "nofilter":
         # use directly the annotated output, instead of the filtered one
-        return "results/{date}/annotated-calls/ref~main/annot~{annotation}/{sample}.bcf"
+        return "results/{date}/annotated-calls/ref~{reference}/annot~{annotation}/{sample}.bcf"
     else:
         # If reference is not main, we are polishing an assembly.
         # Here, there is no need to structural variants or annotation based filtering.

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -601,8 +601,11 @@ def get_target_events(wildcards):
 
 
 def get_control_fdr_input(wildcards):
-    if wildcards.reference == "main":
+    if wildcards.reference == "main" and widlcards.filter != "nofilter":
         return "results/{date}/filtered-calls/ref~{reference}/annot~{annotation}/{sample}.{filter}.bcf"
+    elif wildcards.reference == "main" and widlcards.filter == "nofilter":
+        # use directly the annotated output, instead of the filtered one
+        return "results/{date}/annotated-calls/ref~main/annot~{annotation}/{sample}.bcf"
     else:
         # If reference is not main, we are polishing an assembly.
         # Here, there is no need to structural variants or annotation based filtering.


### PR DESCRIPTION
# Description

<!-- Add a more detailed description of the changes if needed. -->
This PR  adds a nofilter flag for variant calls. This flag was already prepared (see wildcards-constrains), but never used. This PR is needed for the benchmarking.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
N/A

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [X] I've updated or supplemented the documentation as needed.
- [X] I've read the [`CODE_OF_CONDUCT.md`] document.
- [X] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
