### PR TITLE
fix: primer clipping add up- and downstream

### DIFF
--- a/workflow/rules/read_clipping.smk
+++ b/workflow/rules/read_clipping.smk
@@ -57,7 +57,7 @@ rule bamclipper:
         "(cp {input.bam} {params.output_dir} &&"
         " cp {input.bai} {params.output_dir} &&"
         " cd {params.output_dir} &&"
-        " bamclipper.sh -b {params.bam} -p {params.bed_path} -n {threads}) "
+        " bamclipper.sh -b {params.bam} -p {params.bed_path} -n {threads} -u 5 -d 5) "
         " > {params.cwd}/{log} 2>&1"
 
 


### PR DESCRIPTION
# Description

When clipping amplicon primers with the bamclipper tool, primers not exactly matching the defined region from the primer.bed file aren't clipped properly. Therefore additional up and downstream positions are added. Maybe this should be done via the config in the future instead of hard coding the numbers

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [x] I've updated or supplemented the documentation as needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
