### PR TITLE
fix: squeeze

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -252,7 +252,7 @@ def get_strain_accessions(wildcards):
         # Get genomes for benchmarking from config
         accessions = config.get("testing", {}).get("benchmark-genomes", [])
         if not accessions:
-            accessions = pd.read_csv(f, squeeze=True)
+            accessions = pd.read_csv(f).squeeze("columns")
         try:
             accessions = accessions[: config["testing"]["limit-strain-genomes"]]
         except KeyError:
@@ -267,7 +267,7 @@ def get_non_cov2_accessions():
 
 
 def load_strain_genomes(f):
-    strain_genomes = pd.read_csv(f, squeeze=True).to_list()
+    strain_genomes = pd.read_csv(f).squeeze("columns").to_list()
     strain_genomes.append("resources/genomes/main.fasta")
     return expand("{strains}", strains=strain_genomes)
 
@@ -924,7 +924,7 @@ def load_filtered_samples(wildcards, assembly_type):
         date=wildcards.date, assembly_type=assembly_type
     ).output.passed_filter.open() as f:
         try:
-            return pd.read_csv(f, squeeze=True, header=None).astype(str).to_list()
+            return pd.read_csv(f, header=None).squeeze("columns").astype(str).to_list()
         except pd.errors.EmptyDataError:
             return []
 


### PR DESCRIPTION
# Description

pd.read_csv(f, squeeze=True) is deprecated and replaced with .squeeze("columns")

## Related Issue

#530 

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [x] I've updated or supplemented the documentation as needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
