### PR TITLE
fix: use latest varlociraptor release and ignore all biases in case of known lineage variant calling

### DIFF
--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - varlociraptor =4.9
+  - varlociraptor =5.3

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -806,7 +806,11 @@ def get_list_of_amplicon_states_assembler(samples):
 
 def get_varlociraptor_bias_flags(wildcards):
     if wildcards.varrange == "lineage-variants":
-        # known variants, we don't want to use bias detection at all
+        # Known variants, we don't want to use bias detection at all.
+        # Rationale: the determined biases are hints for artifacts, which are particularly
+        # important to maintain a high precision with denovo calls. When there is prior knowledge
+        # about a variant like here, they are too conservative. E.g., when I see a typical omicron
+        # variant in a sample, I tend to believe it even if it happens to have a strand bias.
         return (
             "--omit-strand-bias --omit-read-orientation-bias --omit-read-position-bias "
             "--omit-softclip-bias --omit-homopolymer-artifact-detection --omit-alt-locus-bias"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -805,6 +805,12 @@ def get_list_of_amplicon_states_assembler(samples):
 
 
 def get_varlociraptor_bias_flags(wildcards):
+    if wildcards.varrange == "lineage-variants":
+        # known variants, we don't want to use bias detection at all
+        return (
+            "--omit-strand-bias --omit-read-orientation-bias --omit-read-position-bias "
+            "--omit-softclip-bias --omit-homopolymer-artifact-detection --omit-alt-locus-bias"
+        )
     if is_amplicon_data(wildcards.sample):
         # no bias detection possible
         return (


### PR DESCRIPTION
# Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [x] I've updated or supplemented the documentation as needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
