### PR TITLE
fix: improved clonality event definition, usage of major subclone for assembly polishing; upgrade to varlociraptor 6.0

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -24,12 +24,6 @@ container: "docker://condaforge/mambaforge"
 containerized: "quay.io/uncovar/uncovar#0.15.1"
 
 
-if config["strain-calling"]["use-gisaid"]:
-
-    envvars:
-        "GISAID_API_TOKEN",
-
-
 include: "rules/common.smk"
 include: "rules/benchmarking_common.smk"
 include: "rules/utils.smk"
@@ -47,15 +41,13 @@ include: "rules/variant_filtration.smk"
 include: "rules/variant_report.smk"
 include: "rules/generate_output.smk"
 include: "rules/benchmarking.smk"
+include: "rules/long_read.smk"
+include: "rules/lineage_variant_calling.smk"
 
 
 if config["data-handling"]["use-data-handling"]:
 
     include: "rules/preprocessing.smk"
-
-
-include: "rules/long_read.smk"
-include: "rules/lineage_variant_calling.smk"
 
 
 if config["data-handling"]["archive-data"]:

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - varlociraptor =5.3
+  - varlociraptor =6.0

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -159,8 +159,8 @@ rule filter_chr0:
 rule assembly_polishing_illumina:
     input:
         fasta="results/{date}/contigs/ordered/{sample}.fasta",
-        bcf="results/{date}/filtered-calls/ref~{sample}/{sample}.clonal.nofilter.orf.bcf",
-        bcfidx="results/{date}/filtered-calls/ref~{sample}/{sample}.clonal.nofilter.orf.bcf.csi",
+        bcf="results/{date}/filtered-calls/ref~{sample}/{sample}.subclonal-major.nofilter.orf.bcf",
+        bcfidx="results/{date}/filtered-calls/ref~{sample}/{sample}.subclonal-major.nofilter.orf.bcf.csi",
     output:
         report(
             "results/{date}/polishing/bcftools-illumina/{sample}.fasta",

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -598,12 +598,16 @@ def get_bwa_index(wildcards):
 
 
 def get_target_events(wildcards):
-    if wildcards.reference == "main" or wildcards.clonality != "clonal":
-        # calling variants against the wuhan reference or we are explicitly interested in subclonal as well
-        return "SUBCLONAL_MINOR SUBCLONAL_MAJOR SUBCLONAL_HIGH CLONAL"
-    else:
-        # only keep clonal variants
+    if wildcards.clonality == "clonal":
         return "CLONAL"
+    elif wildcards.clonality == "subclonal-major":
+        return "CLONAL SUBCLONAL_MAJOR SUBCLONAL_HIGH"
+    elif wildcards.clonality == "subclonal-high":
+        return "CLONAL SUBCLONAL_HIGH"
+    elif wildcards.clonality == "subclonal":
+        return "CLONAL SUBCLONAL_MAJOR SUBCLONAL_HIGH SUBCLONAL_MINOR"
+    else:
+        raise ValueError(f"Unsupported clonality value: {wildcards.clonality}")
 
 
 def get_control_fdr_input(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1673,7 +1673,7 @@ def get_genome_annotation(suffix=""):
 wildcard_constraints:
     sample="[^/.]+",
     vartype="|".join(VARTYPES),
-    clonality="subclonal|clonal",
+    clonality="subclonal|clonal|subclonal-major|subclonal-high",
     annotation="orf|protein",
     filter="|".join(
         list(map(re.escape, config["variant-calling"]["filters"])) + ["nofilter"]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -11,8 +11,18 @@ import urllib.request
 from snakemake.utils import validate
 
 
+if config["strain-calling"]["use-gisaid"]:
+
+    envvars:
+        "GISAID_API_TOKEN",
+
+
 VARTYPES = ["SNV", "MNV", "INS", "DEL", "REP", "INV", "DUP"]
+
+
 ILLUMINA_VARRANGE = ["small", "structural"]
+
+
 ONT_VARRANGE = ["homopolymer-medaka", "homopolymer-longshot"]
 ION_VARRANGE = ["small", "structural"]
 

--- a/workflow/rules/variant_filtration.smk
+++ b/workflow/rules/variant_filtration.smk
@@ -35,7 +35,7 @@ rule control_fdr:
     conda:
         "../envs/varlociraptor.yaml"
     shell:
-        "varlociraptor filter-calls control-fdr --local {input} --var {wildcards.vartype} "
+        "varlociraptor filter-calls control-fdr --mode local-smart {input} --var {wildcards.vartype} "
         "--events {params.events} --fdr {params.fdr} > {output} 2> {log}"
 
 


### PR DESCRIPTION
Important: 
Before, we used only clonal variants (VAF=100%) for assembly polishing. This PR changes this behavior to also use major subclonal variants to polish the assembly (VAF>=50%). This is open for discussion. My idea is: the assembly should represent the major subclone in the sample (if there are multiple ones). If we only use clonal variants like before, the assembly could contain individual loci where the majority of the reads disagree with the assembly. This is not what we would want I think, since it also hampers the predictions of pangolin.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [x] I've updated or supplemented the documentation as needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
