### PR TITLE
fix: use homopolymer-pair-HMM-mode of Varlociraptor in case of nanopore reads

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1587,6 +1587,16 @@ def get_checked_mode():
     raise TypeError(f'Mode {mode} not recognized. Can be "patient" or "environment".')
 
 
+def get_varlociraptor_preprocess_flags(wildcards):
+    technology = samples.loc[wildcards.sample, "technology"]
+    if technology == "ont":
+        return "--pairhmm-mode homopolymer"
+    elif technolgy == "illumina" or technology == "ion":
+        return ""
+    else:
+        raise NotImplementedError(f"Technology {technology} not supported.")
+
+
 def get_input_by_mode(wildcard):
     paths = [
         expand(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1588,7 +1588,7 @@ def get_checked_mode():
 
 
 def get_varlociraptor_preprocess_flags(wildcards):
-    technology = pep.sample_table.loc[wildcards.sample, "technology"]
+    technology = get_technology(wildcards)
     if technology == "ont":
         return "--pairhmm-mode homopolymer"
     elif technology == "illumina" or technology == "ion":

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1588,9 +1588,7 @@ def get_checked_mode():
 
 
 def get_varlociraptor_preprocess_flags(wildcards):
-    samples = get_samples_for_date(wildcards.date)
-
-    technology = samples.loc[wildcards.sample, "technology"]
+    technology = pep.sample_table.loc[wildcards.sample, "technology"]
     if technology == "ont":
         return "--pairhmm-mode homopolymer"
     elif technolgy == "illumina" or technology == "ion":

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1587,16 +1587,6 @@ def get_checked_mode():
     raise TypeError(f'Mode {mode} not recognized. Can be "patient" or "environment".')
 
 
-def get_varlociraptor_preprocess_flags(wildcards):
-    technology = samples.loc[wildcards.sample, "technology"]
-    if technology == "ont":
-        return "--pairhmm-mode homopolymer"
-    elif technolgy == "illumina" or technology == "ion":
-        return ""
-    else:
-        raise NotImplementedError(f"Technology {technology} not supported.")
-
-
 def get_input_by_mode(wildcard):
     paths = [
         expand(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1588,6 +1588,8 @@ def get_checked_mode():
 
 
 def get_varlociraptor_preprocess_flags(wildcards):
+    samples = get_samples_for_date(wildcards.date)
+
     technology = samples.loc[wildcards.sample, "technology"]
     if technology == "ont":
         return "--pairhmm-mode homopolymer"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1591,7 +1591,7 @@ def get_varlociraptor_preprocess_flags(wildcards):
     technology = pep.sample_table.loc[wildcards.sample, "technology"]
     if technology == "ont":
         return "--pairhmm-mode homopolymer"
-    elif technolgy == "illumina" or technology == "ion":
+    elif technology == "illumina" or technology == "ion":
         return ""
     else:
         raise NotImplementedError(f"Technology {technology} not supported.")

--- a/workflow/rules/variant_calling.smk
+++ b/workflow/rules/variant_calling.smk
@@ -143,13 +143,12 @@ rule varlociraptor_preprocess:
         temp("results/{date}/observations/ref~{reference}/{sample}.{varrange}.bcf"),
     params:
         depth=config["variant-calling"]["max-read-depth"],
-        extra=get_varlociraptor_preprocess_flags,
     log:
         "logs/{date}/varlociraptor/preprocess/ref~{reference}/{sample}.{varrange}.log",
     conda:
         "../envs/varlociraptor.yaml"
     shell:
-        "varlociraptor preprocess variants {params.extra} --candidates {input.candidates} "
+        "varlociraptor preprocess variants --candidates {input.candidates} "
         "{input.ref} --bam {input.bam} --max-depth {params.depth} --output {output} 2> {log}"
 
 

--- a/workflow/rules/variant_calling.smk
+++ b/workflow/rules/variant_calling.smk
@@ -143,12 +143,13 @@ rule varlociraptor_preprocess:
         temp("results/{date}/observations/ref~{reference}/{sample}.{varrange}.bcf"),
     params:
         depth=config["variant-calling"]["max-read-depth"],
+        extra=get_varlociraptor_preprocess_flags,
     log:
         "logs/{date}/varlociraptor/preprocess/ref~{reference}/{sample}.{varrange}.log",
     conda:
         "../envs/varlociraptor.yaml"
     shell:
-        "varlociraptor preprocess variants --candidates {input.candidates} "
+        "varlociraptor preprocess variants {params.extra} --candidates {input.candidates} "
         "{input.ref} --bam {input.bam} --max-depth {params.depth} --output {output} 2> {log}"
 
 


### PR DESCRIPTION
nanopore suffers from homopolymer errors. Varlociraptor can deal with them by having additional states in its pairHMM used for realignment of reads against considered alleles. This mode has to be explicitly activated whenever we process a nanopore sample.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [x] I've updated or supplemented the documentation as needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
