### PR TITLE
fix: changes in path requirements for snakedeploy

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -214,7 +214,7 @@ def get_fastqs(wildcards):
 def get_resource(name):
     if "https" in str(Path(workflow.snakefile)):
         url = str(urllib.request(workflow.snakefile))
-        return str(url.rsplit("/", 2)[0] / "resources" / name)
+        return str(url.rsplit("/", 2)[0]) + "/" + "resources" + "/" + name
     else:
         return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name)
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -212,7 +212,11 @@ def get_fastqs(wildcards):
 
 
 def get_resource(name):
-    return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name)
+    if "https" in str(Path(workflow.snakefile)):
+        url=str(urllib.request(workflow.snakefile))
+        return str(url.rsplit('/', 2)[0] / "resources" / name)
+    else:
+        return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name)
 
 
 def get_report_input(pattern):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -213,8 +213,8 @@ def get_fastqs(wildcards):
 
 def get_resource(name):
     if "https" in str(Path(workflow.snakefile)):
-        url=str(urllib.request(workflow.snakefile))
-        return str(url.rsplit('/', 2)[0] / "resources" / name)
+        url = str(urllib.request(workflow.snakefile))
+        return str(url.rsplit("/", 2)[0] / "resources" / name)
     else:
         return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name)
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -213,7 +213,7 @@ def get_fastqs(wildcards):
 
 
 def get_resource(name):
-    return workflow.source_path(f"../../resources/{name}")
+    return workflow.sourcepath(f"../../resources/{name}")
 
 
 def get_report_input(pattern):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -213,7 +213,9 @@ def get_fastqs(wildcards):
 
 def get_resource(name):
     if "https" in str(Path(workflow.snakefile)):
-        return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name).replace("/", "//", 1)
+        return str(
+            (Path(workflow.snakefile).parent.parent.parent / "resources") / name
+        ).replace("\/", "//", 1)
     else:
         return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name)
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -213,8 +213,7 @@ def get_fastqs(wildcards):
 
 def get_resource(name):
     if "https" in str(Path(workflow.snakefile)):
-        url = str(urllib.request(workflow.snakefile))
-        return str(url.rsplit("/", 2)[0]) + "/" + "resources" + "/" + name
+        return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name).replace("/", "//", 1)
     else:
         return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name)
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -213,7 +213,8 @@ def get_fastqs(wildcards):
 
 
 def get_resource(name):
-    return workflow.source_path(f"../../resources/{name}")
+    dirname = os.path.dirname
+    return f"{dirname((workflow.basedir))}/resources/{name}"
 
 
 def get_report_input(pattern):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -213,8 +213,7 @@ def get_fastqs(wildcards):
 
 
 def get_resource(name):
-    dirname = os.path.dirname
-    return f"{dirname((workflow.basedir))}/resources/{name}"
+    return workflow.source_path(f"../../resources/{name}")
 
 
 def get_report_input(pattern):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -213,15 +213,7 @@ def get_fastqs(wildcards):
 
 
 def get_resource(name):
-    if "https" in str(Path(workflow.snakefile)):
-        dirname = os.path.dirname
-        path_snakefile = str(workflow.snakefile)
-        path_new = dirname(dirname(path_snakefile))
-        folder = "resources"
-        path_complete = f"{path_new}/{folder}/{name}"
-        return path_complete
-    else:
-        return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name)
+    return workflow.source_path(f"../../resources/{name}")
 
 
 def get_report_input(pattern):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -213,7 +213,7 @@ def get_fastqs(wildcards):
 
 
 def get_resource(name):
-    return workflow.sourcepath(f"../../resources/{name}")
+    return workflow.source_path(f"../../resources/{name}")
 
 
 def get_report_input(pattern):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -4,6 +4,7 @@
 # except according to those terms.
 
 from pathlib import Path
+import os.path
 import pandas as pd
 import re
 import random
@@ -213,9 +214,12 @@ def get_fastqs(wildcards):
 
 def get_resource(name):
     if "https" in str(Path(workflow.snakefile)):
-        return str(
-            (Path(workflow.snakefile).parent.parent.parent / "resources") / name
-        ).replace("\/", "//", 1)
+        dirname = os.path.dirname
+        path_snakefile = str(workflow.snakefile)
+        path_new = dirname(dirname(path_snakefile))
+        folder = "resources"
+        path_complete = f"{path_new}/{folder}/{name}"
+        return path_complete
     else:
         return str((Path(workflow.snakefile).parent.parent.parent / "resources") / name)
 


### PR DESCRIPTION
# Description

<!-- Add a more detailed description of the changes if needed. --> Changed the path fetching in common.smk -> get_resource(). Should fetch the total link if snake deploy is used so files can be used from the resources folder in the repository.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [x] I've updated or supplemented the documentation as needed.
- [x] I've read the [`CODE_OF_CONDUCT.md`] document.
- [x] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
