### PR TITLE
feat: ignore the timestamp on the human genome reference file

### DIFF
--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -184,7 +184,7 @@ rule create_krona_chart:
 rule combine_references:
     input:
         "resources/genomes/main.fasta",
-        "resources/genomes/human-genome.fna.gz",
+        ancient("resources/genomes/human-genome.fna.gz"),
     output:
         "resources/genomes/main-and-human-genome.fna.gz",
     log:


### PR DESCRIPTION
# Description

Downloading human genome fasta files is a time intensive task where ignoring the timestamp could save time when running the pipeline. I have marked the corresponding input to ignore timestamps using snakemakes ancient directive.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [X] I've updated or supplemented the documentation as needed.
- [X] I've read the [`CODE_OF_CONDUCT.md`] document.
- [X] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
