### PR TITLE
fix: remove -r flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       #- Pre-Commit
     strategy:
       matrix:
-        rule: [all, all -npr]
+        rule: [all, all -np]
         # disable ont actions
         technology: [all, illumina, ont, ion]
         # technology: [all, illumina, ion]
@@ -141,11 +141,11 @@ jobs:
         with:
           directory: .tests
           snakefile: workflow/Snakefile
-          args: "-pr --use-conda --show-failed-logs --cores 2 --resources ncbi_api_requests=1 --conda-cleanup-pkgs cache --conda-frontend mamba ${{ matrix.rule }}"
+          args: "-p --use-conda --show-failed-logs --cores 2 --resources ncbi_api_requests=1 --conda-cleanup-pkgs cache --conda-frontend mamba ${{ matrix.rule }}"
 
       - name: Test report
         uses: snakemake/snakemake-github-action@v1.25.1
-        if: startsWith(matrix.rule, 'all -npr') != true
+        if: startsWith(matrix.rule, 'all -np') != true
         with:
           directory: .tests
           snakefile: workflow/Snakefile
@@ -153,14 +153,14 @@ jobs:
 
       - name: Upload report
         uses: actions/upload-artifact@v3
-        if: matrix.technology == 'all' && matrix.rule != 'all -npr'
+        if: matrix.technology == 'all' && matrix.rule != 'all -np'
         with:
           name: report-rule-${{ matrix.rule }}-${{ matrix.technology }}-${{ matrix.seq_method }}
           path: .tests/results/patient-reports/2022-01-01.zip
 
       - name: Upload logs
         uses: actions/upload-artifact@v3
-        if: matrix.technology == 'all' && matrix.rule != 'all -npr'
+        if: matrix.technology == 'all' && matrix.rule != 'all -np'
         with:
           name: log-rule-${{ matrix.rule }}-technology-${{ matrix.technology }}
           path: .tests/logs/
@@ -323,7 +323,7 @@ jobs:
 
       - name: Test report
         uses: snakemake/snakemake-github-action@v1.25.1
-        if: startsWith(matrix.rule, 'all -npr') != true
+        if: startsWith(matrix.rule, 'all -np') != true
         with:
           directory: .tests
           snakefile: workflow/Snakefile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,7 +319,7 @@ jobs:
         with:
           directory: .tests
           snakefile: workflow/Snakefile
-          args: "-pr --use-conda --show-failed-logs --cores 2 --resources ncbi_api_requests=1 --conda-cleanup-pkgs cache --conda-frontend mamba ${{ matrix.rule }}"
+          args: "-p --use-conda --show-failed-logs --cores 2 --resources ncbi_api_requests=1 --conda-cleanup-pkgs cache --conda-frontend mamba ${{ matrix.rule }}"
 
       - name: Test report
         uses: snakemake/snakemake-github-action@v1.25.1


### PR DESCRIPTION
# Description

after the docker container in the Snakemake github action is updated to Snakemake version 8.0.1, the `-r` flag is discontinued

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [ ] I've updated or supplemented the documentation as needed.
- [ ] I've read the [`CODE_OF_CONDUCT.md`] document.
- [ ] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
