### PR TITLE
Revert "feat: FLiRT Mutations column (#664)"

### DIFF
--- a/.tests/config/config.yaml
+++ b/.tests/config/config.yaml
@@ -166,12 +166,6 @@ mixtures:
     - "_MIX_B-1-1-7_PERC_90_MIX_B-1-351_PERC_10"
 
 # mutations to be highlighted (protein name -> variants)
-
-flirt:
-  S:
-    - F456L
-    - R346T
-
 mth:
   S:
     - N501Y

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,7 +21,7 @@ data-handling:
   # flag for archiving data
   # True: data is archived in path defined below
   # False: data is not archived
-  archive-data: False
+  archive-data: True
   # path of incoming data, which is moved to the
   # data directory by the preprocessing script
   incoming: ../incoming/
@@ -34,7 +34,7 @@ data-handling:
 quality-criteria:
   illumina:
     # minimal length of acceptable reads
-    min-length-reads: 100
+    min-length-reads: 30
     # average quality of acceptable reads (PHRED)
     min-PHRED: 20
   ont:
@@ -61,9 +61,9 @@ preprocessing:
   # ARTIC primer version to clip from reads. See
   # https://github.com/artic-network/artic-ncov2019/tree/master/primer_schemes/nCoV-2019/V4
   # for more information
-  artic-primer-version: 4
+  artic-primer-version: 3
   # path to amplicon primers in bed format for hard-clipping on paired end files (illumina) or url to file that should be downloaded
-  amplicon-primers: "resources/SARS-CoV-2-artic-v4_1.primer.bed"
+  amplicon-primers: "resources/nCoV-2019.primer.bed"
   # GenBank accession of reference sequence of the amplicon primers
   amplicon-reference: "MN908947"
 
@@ -124,12 +124,6 @@ strain-calling:
     B.1.617.2: OK091006
 
 # mutations to be highlighted (protein name -> variants)
-
-flirt:
-  S:
-    - F456L
-    - R346T
-
 mth:
   S:
     - L18F

--- a/resources/report-table-formatter.js
+++ b/resources/report-table-formatter.js
@@ -91,9 +91,6 @@
       }
 
   },
-  "FLiRT Mutations": function format(value) {
-    return this["variant helper"](value, true);
-  },
   "VOC Mutations": function format(value) {
       return this["variant helper"](value, true);
   },

--- a/workflow/rules/generate_output.smk
+++ b/workflow/rules/generate_output.smk
@@ -153,7 +153,6 @@ rule overview_table_patient_csv:
             wildcards, "all samples"
         ),
         mth=config.get("mth"),
-        flirt=config.get("flirt"),
         samples=lambda wildcards: get_samples_for_date(wildcards.date),
         mode=config["mode"],
     log:
@@ -179,7 +178,6 @@ use rule overview_table_patient_csv as overview_table_environment_csv with:
         qc_data="results/{date}/tables/environment-overview.csv",
     params:
         mth=config.get("mth"),
-        flirt=config.get("flirt"),
         samples=lambda wildcards: get_samples_for_date(wildcards.date),
         mode=config["mode"],
     log:
@@ -373,7 +371,6 @@ rule snakemake_reports_patient:
         expand_samples_for_date(
             ["results/{{date}}/lineage-variant-report/{sample}.lineage-variants"]
         ),
-        # lambda wildcards: "results/{date}/lineage-variant-report/all",
         lambda wildcards: expand(
             "results/{{date}}/vcf-report/{target}.{filter}.{annotation}",
             target=get_samples_for_date(wildcards.date) + ["all"],
@@ -383,10 +380,10 @@ rule snakemake_reports_patient:
         # 3. Sequencing Details
         "results/{date}/qc/laboratory/multiqc.html",
         "results/{date}/plots/coverage-reference-genome.png",
-        # "results/{date}/plots/coverage-assembled-genome.png",
-        # lambda wildcards: "results/{date}/plots/primer-clipping-intervals.svg"
-        # if any_sample_is_amplicon(wildcards)
-        # else [],
+        "results/{date}/plots/coverage-assembled-genome.png",
+        lambda wildcards: "results/{date}/plots/primer-clipping-intervals.svg"
+        if any_sample_is_amplicon(wildcards)
+        else [],
         # 4. Assembly
         "results/{date}/filter-overview",
         "results/{date}/pangolin-call-overview",
@@ -409,6 +406,8 @@ rule snakemake_reports_patient:
         "results/patient-reports/{date}.zip",
     params:
         for_testing=get_if_testing("--snakefile ../workflow/Snakefile"),
+    conda:
+        "../envs/snakemake.yaml"
     log:
         "logs/snakemake_reports/{date}.log",
     shell:
@@ -424,10 +423,10 @@ use rule snakemake_reports_patient as snakemake_reports_environment with:
             "results/{{date}}/{execution_mode}/overview/",
             execution_mode=get_checked_mode(),
         ),
-        # "results/{date}/plots/all.major-strain.strains.kallisto.svg",
-        # expand_samples_for_date(
-        #     ["results/{{date}}/plots/strain-calls/{sample}.strains.kallisto.svg"]
-        # ),
+        "results/{date}/plots/all.major-strain.strains.kallisto.svg",
+        expand_samples_for_date(
+            ["results/{{date}}/plots/strain-calls/{sample}.strains.kallisto.svg"]
+        ),
         # 2. Variant Call Details
         expand_samples_for_date(
             ["results/{{date}}/lineage-variant-report/{sample}.lineage-variants"]
@@ -445,8 +444,3 @@ use rule snakemake_reports_patient as snakemake_reports_environment with:
         "results/environment-reports/{date}.zip",
     log:
         "logs/snakemake_reports/{date}.log",
-
-
-# rule output_sample_sheet:
-#     input:
-#         Path(pep.config_file()).parent / pep.config()["sample_table"],

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -115,9 +115,6 @@ properties:
         description: flag for using gisaid or genbank
       lineage-references:
         type: object
-  flirt:
-    type: object
-    description: mutations to be highlighted (protein name -> variants)
   mth:
     type: object
     description: mutations to be highlighted (protein name -> variants)
@@ -133,5 +130,4 @@ required:
   - assembly
   - variant-calling
   - strain-calling
-  - flirt
   - mth

--- a/workflow/scripts/generate-overview-table.py
+++ b/workflow/scripts/generate-overview-table.py
@@ -193,7 +193,6 @@ AA_ALPHABET_TRANSLATION = {
 }
 
 for sample, file in iter_with_samples(snakemake.input.bcf):
-    flirt_mutations = {}
     mutations_of_interest = {}
     other_mutations = {}
 
@@ -229,14 +228,11 @@ for sample, file in iter_with_samples(snakemake.input.bcf):
 
                     hgvsp = f"{feature}:{alteration}"
                     entry = (hgvsp, f"{vaf:.3f}")
-                    if alteration in snakemake.params.flirt.get(feature, {}):
-                        insert_entry(flirt_mutations, hgvsp, vaf)
-                    elif alteration in snakemake.params.mth.get(feature, {}):
+                    if alteration in snakemake.params.mth.get(feature, {}):
                         insert_entry(mutations_of_interest, hgvsp, vaf)
                     else:
                         insert_entry(other_mutations, hgvsp, vaf)
 
-    data.loc[sample, "FLiRT Mutations"] = fmt_variants(flirt_mutations)
     data.loc[sample, "VOC Mutations"] = fmt_variants(mutations_of_interest)
     data.loc[sample, "Other Mutations"] = fmt_variants(other_mutations)
 


### PR DESCRIPTION
This reverts commit f77d42e2154a95b6ca0e2c127df8ca134eda1789.

# Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [ ] I've updated or supplemented the documentation as needed.
- [ ] I've read the [`CODE_OF_CONDUCT.md`] document.
- [ ] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
