### PR TITLE
fix: fix log not being found by the system

### DIFF
--- a/workflow/rules/read_clipping.smk
+++ b/workflow/rules/read_clipping.smk
@@ -44,7 +44,6 @@ rule bamclipper:
         ),
     params:
         output_dir=get_output_dir,
-        cwd=lambda w: os.getcwd(),
         bed_path=lambda w, input: os.path.join(os.getcwd(), input.bedpe),
         bam=lambda w, input: os.path.basename(input.bam),
     log:
@@ -57,7 +56,7 @@ rule bamclipper:
         " cp {input.bai} {params.output_dir} &&"
         " cd {params.output_dir} &&"
         " bamclipper.sh -b {params.bam} -p {params.bed_path} -n {threads} -u 5 -d 5) "
-        " > {params.cwd}/{log} 2>&1"
+        " > {log} 2>&1"
 
 
 rule fgbio:


### PR DESCRIPTION
# Description

Currently log cannot be found by the system and workflow fails. Removing the cwd parameter from the path of the log fixes it.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [x] I've updated or supplemented the documentation as needed.
- [ ] I've read the [`CODE_OF_CONDUCT.md`] document.
- [ ] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
