### PR TITLE
fix: fix file not found error on shared fs storage

### DIFF
--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -136,10 +136,8 @@ rule order_contigs:
     shadow:
         "minimal"
     shell:
-        "(mkdir -p {params.outdir}/{wildcards.sample} && cd {params.outdir}/{wildcards.sample} &&"
-        " ragtag.py scaffold -C -w ../../../../../{input.reference} ../../../../../{input.contigs} &&"
-        " cd ../../../../../ && mv {params.outdir}/{wildcards.sample}/ragtag_output/ragtag.scaffold.fasta {output})"
-        " > {log} 2>&1"
+        " ragtag.py scaffold -C -o {params.outdir}/{wildcards.sample} {input.reference} {input.contigs} &&"
+        " mv {params.outdir}/{wildcards.sample}/ragtag.scaffold.fasta {output} > {log} 2>&1"
 
 
 rule filter_chr0:

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -136,7 +136,7 @@ rule order_contigs:
     shadow:
         "minimal"
     shell:
-        " ragtag.py scaffold -C -o {params.outdir}/{wildcards.sample} {input.reference} {input.contigs} &&"
+        " ragtag.py scaffold -C -w -o {params.outdir}/{wildcards.sample} {input.reference} {input.contigs} &&"
         " mv {params.outdir}/{wildcards.sample}/ragtag.scaffold.fasta {output} > {log} 2>&1"
 
 


### PR DESCRIPTION
Usage of relative paths leads to files not being found on shared filesystem storage systems. The shell command is fixed to use the output directory of the tool without cd'ing to the folder and needing to use relative paths.

# Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've formatted the PR title in accordance with the [structure of the conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I've updated the code style using [`pre-commit`](https://ikim-essen.github.io/uncovar/dev-guide/contributing/#pre-commit) if needed.
- [ ] I've updated or supplemented the documentation as needed.
- [ ] I've read the [`CODE_OF_CONDUCT.md`] document.
- [ ] I've read the [`CONTRIBUTING.md`] guide.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->

[`CODE_OF_CONDUCT.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CODE_OF_CONDUCT.md
[`CONTRIBUTING.md`]: https://github.com/IKIM-Essen/uncovar/blob/master/CONTRIBUTING.md
